### PR TITLE
adding 'User' as class_name to giver and receiver

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -11,7 +11,7 @@
 #
 class Transaction < ApplicationRecord
   belongs_to :item
-  belongs_to :giver
-  belongs_to :receiver
+  belongs_to :giver, class_name: "User"
+  belongs_to :receiver, class_name: "User"
   validates_presence_of :giver_id, :item_id, :receiver_id
 end


### PR DESCRIPTION
@DenzelBraithwaite When the name of the relation doesn’t match the name of the model:

class Transaction < ApplicationRecord
  belongs_to :giver, class_name: "User"
  belongs_to :receiver, class_name: "User"

Added `class_name: "User"` to link to giver and receiver. 