### PR TITLE
Timezone reset

### DIFF
--- a/app/assets/stylesheets/components/_message.scss
+++ b/app/assets/stylesheets/components/_message.scss
@@ -1,6 +1,11 @@
 // this component is for styling the messages in each request.
 // refer to usage in views/requests/show.html.erb
 
+// background color of the card for messages
+.messages {
+  background-color: rgba($light-green, 0.15);
+}
+
 // To style the wrapping div
 .message-row {
   margin-bottom: 10px;
@@ -11,10 +16,10 @@
 .sender-style, .receiver-style {
   width: 70%;
   max-width: 400px;
-  border-radius: 4px;
+  border-radius: 10px;
   padding: 8px;
   min-height: 80px;
-  color: rgba(black, 0.9)
+  color: rgba(black, 0.9);
 }
 
 // changing the boilerplate colors to our theme colors in Figma
@@ -24,4 +29,13 @@
 
 .receiver-style {
   background-color: rgba($light-green, 0.5);
+}
+
+// button to send messages
+.send-messages {
+  .button {
+    height: 62px;
+    font-size: 14px;
+    font-weight: 400;
+  }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  around_action :switch_time_zone, if: :current_user
 
 
   protect_from_forgery with: :exception, prepend: true
@@ -12,5 +13,15 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[username address])
 
     devise_parameter_sanitizer.permit(:account_update, keys: %i[username address])
+  end
+
+  private
+
+  # Rails apps use UTC as the default timezone.
+  # Our 'Users' table has a column "time_zone" which sets EST as default timezone.
+  # This method switch the timezone according to the current user's.
+  # Users can change their timezone in profile page (to be created) as appropriate.
+  def switch_time_zone(&block)
+    Time.use_zone(current_user.time_zone, &block)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  time_zone              :string           default("Eastern Time (US & Canada)")
 #  username               :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,7 +1,7 @@
 <div id="message-<%= message.id %>">
   <small>
     <strong><%= message.user.username %></strong>
-    <i><%= message.created_at.strftime("%a %b %e at %l:%M %p") %></i>
+    <i><%= message.created_at.strftime("%b %e at %l:%M %p") %></i>
   </small>
   <p><%= message.content %></p>
 </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -3,52 +3,60 @@
     <h5>Messages</h5>
   </div>
   <div class="container my-3">
-    <% @requests.each do |request| %>
-      <%= link_to request_path(request) do %>
-        <%# each request is a flex card %>
-        <div class="ripple shadow request-card <%= request.item.status == 2 ? 'donated' : '' %>">
-          <%# image is the first div %>
-          <%# To insert dynamic images for all items %>
-          <%= image_tag "ingredients/cucumber_two.jpg", class: "img" %>
-          <%# details is the second div %>
-          <div class="details">
-            <% if current_user == request.receiver %>
-              <span><%= request.giver.username %></span>
-            <% elsif current_user == request.giver %>
-              <span><%= request.receiver.username %></span>
-            <% end %>
-            <strong><%= request.item.name %></strong>
-            <% if request.item.status == 2 %>
-              <em><%= '<This item was donated>' if request.item.status == 2 %></em>
-            <% else %>
-              <%# only part of the message is previewed if it's too long %>
-              <% if current_user == request.messages.last.user %>
-                <% if request.messages.last.content.chars.count > 21 %>
-                  <em>You: <%= request.messages.last.content.chars[0..20].join %>...</em>
-                <% else %>
-                  <em>You: <%= request.messages.last.content %></em>
+    <%# if @requests is not empty, show them. Otherwise, "You don't have any requests." %>
+    <% if @requests %>
+      <% @requests.each do |request| %>
+        <%# only if a request has messages, show it in the page %>
+        <% if request.messages %>
+          <%= link_to request_path(request) do %>
+            <%# each request is a flex card %>
+            <div class="ripple shadow request-card <%= request.item.status == 2 ? 'donated' : '' %>">
+              <%# image is the first div %>
+              <%# To insert dynamic images for all items %>
+              <%= image_tag "ingredients/cucumber_two.jpg", class: "img" %>
+              <%# details is the second div %>
+              <div class="details">
+                <% if current_user == request.receiver %>
+                  <span><%= request.giver.username %></span>
+                <% elsif current_user == request.giver %>
+                  <span><%= request.receiver.username %></span>
                 <% end %>
-              <% else %>
-                <% if request.messages.last.content.chars.count > 25 %>
-                  <em><%= request.messages.last.content.chars[0..24].join %>...</em>
+                <strong><%= request.item.name %></strong>
+                <% if request.item.status == 2 %>
+                  <em><%= '<This item was donated>' if request.item.status == 2 %></em>
                 <% else %>
-                  <em><%= request.messages.last.content %></em>
+                  <%# only part of the message is previewed if it's too long %>
+                  <% if current_user == request.messages.last.user %>
+                    <% if request.messages.last.content.chars.count > 21 %>
+                      <em>You: <%= request.messages.last.content.chars[0..20].join %>...</em>
+                    <% else %>
+                      <em>You: <%= request.messages.last.content %></em>
+                    <% end %>
+                  <% else %>
+                    <% if request.messages.last.content.chars.count > 25 %>
+                      <em><%= request.messages.last.content.chars[0..24].join %>...</em>
+                    <% else %>
+                      <em><%= request.messages.last.content %></em>
+                    <% end %>
+                  <% end %>
                 <% end %>
-              <% end %>
-            <% end %>
-          </div>
-          <%# last message's received time is the third div %>
-          <div class="message-time">
-            <% if request.messages.last.created_at > 6.days.from_now %>
-              <%= request.messages.last.created_at.strftime("%D") %>
-            <% elsif request.messages.last.created_at > 1.day.from_now %>
-              <%= request.messages.last.created_at.strftime("%a") %>
-            <% else %>
-              Today
-            <% end %>
-          </div>
-        </div>
+              </div>
+              <%# last message's received time is the third div %>
+              <div class="message-time">
+                <% if request.messages.last.created_at > 6.days.from_now %>
+                  <%= request.messages.last.created_at.strftime("%D") %>
+                <% elsif request.messages.last.created_at > 1.day.from_now %>
+                  <%= request.messages.last.created_at.strftime("%a") %>
+                <% else %>
+                  Today
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
       <% end %>
+    <% else %>
+      <em>You don't have any requests to date.</em>
     <% end %>
   </div>
 </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -15,16 +15,18 @@
     <% end %>
   </div>
 
-  <%= simple_form_for [@request, @message],
-  remote: true,
-  html: {data: {action: "ajax:success->request-subscription#resetForm" }, class: "d-flex"} do |f|
-  %>
-    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-    <%= f.input :content,
-      label: false,
-      placeholder: "Message ##{@request.item.name}",
-      wrapper_html: {class: "flex-grow-1"}
+  <div class="send-messages">
+    <%= simple_form_for [@request, @message],
+    remote: true,
+    html: {data: {action: "ajax:success->request-subscription#resetForm" }, class: "d-flex"} do |f|
     %>
-    <%= f.submit "Send", class: "btn btn-primary" %>
-  <% end %>
+      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+      <%= f.input :content,
+        label: false,
+        placeholder: "Message ##{@request.item.name}",
+        wrapper_html: {class: "flex-grow-1"}
+      %>
+      <%= f.submit "Send", class: "button" %>
+    <% end %>
+  </div>
 </div>

--- a/db/migrate/20220531184620_add_time_zone_to_user.rb
+++ b/db/migrate/20220531184620_add_time_zone_to_user.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :time_zone, :string, default: "Eastern Time (US & Canada)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_28_185754) do
+ActiveRecord::Schema.define(version: 2022_05_31_184620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 2022_05_28_185754) do
     t.string "address"
     t.float "latitude"
     t.float "longitude"
+    t.string "time_zone", default: "Eastern Time (US & Canada)"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -11,6 +11,7 @@
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  time_zone              :string           default("Eastern Time (US & Canada)")
 #  username               :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,11 +2310,6 @@ css-prefers-color-scheme@^3.1.1:
   dependencies:
     postcss "^7.0.5"
 
-css-ripple-effect@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/css-ripple-effect/-/css-ripple-effect-1.0.5.tgz#6963b752aaf59babbd3fea3ec0da5d44e9122efb"
-  integrity sha512-wtYlyYA0MQklWNQw60XSE1uUJrTKOL6JZbQhcqa3LzVLW0OqZnswkvctbPo/8W2MI8BfHAzyCfja2tjVVIxoww==
-
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"


### PR DESCRIPTION
@DenzelBraithwaite Please review changes:

1. Requests#show page
- Message received time is using Rails' default timezone (UTC). To update that, I've added `time_zone` column to the `Users` table and set it to EST be default. In that case, all users can update their timezones further in their edit_profile page (this page to be created next week).

![Screenshot 2022-05-31 at 3 31 43 PM](https://user-images.githubusercontent.com/75033073/171271161-67996cb3-f5a8-4f61-9018-14dc421ffc13.png)

2. Requests#index page
- Added logics in so it won’t crash when there’s no requests || no messages for a request.