### PR TITLE
Message model - request_id

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  request_id :bigint
+#  request_id :bigint           not null
 #  user_id    :bigint           not null
 #
 class Message < ApplicationRecord

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2022_06_01_205755) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "request_id"
+    t.bigint "request_id", null: false
     t.index ["request_id"], name: "index_messages_on_request_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -6,7 +6,7 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  request_id :bigint
+#  request_id :bigint           not null
 #  user_id    :bigint           not null
 #
 require "test_helper"


### PR DESCRIPTION
Realised It was accidentally removed in the master, hence adding back `:request_id` as `not null` in the `Message` model.

For anyone who has time, please review this PR :)