### PR TITLE
removed lat and lon from items. User will use User.address for Geocoder

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,8 +6,6 @@
 #  description     :text
 #  expiration_date :date
 #  item_type       :string
-#  latitude        :float
-#  longitude       :float
 #  name            :string
 #  status          :integer          default("available")
 #  created_at      :datetime         not null

--- a/db/migrate/20220604160852_remove_coordinates_from_items.rb
+++ b/db/migrate/20220604160852_remove_coordinates_from_items.rb
@@ -1,0 +1,6 @@
+class RemoveCoordinatesFromItems < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :items, :latitude, :float
+    remove_column :items, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_01_205755) do
+ActiveRecord::Schema.define(version: 2022_06_04_160852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,8 +93,6 @@ ActiveRecord::Schema.define(version: 2022_06_01_205755) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
-    t.float "latitude"
-    t.float "longitude"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -6,8 +6,6 @@
 #  description     :text
 #  expiration_date :date
 #  item_type       :string
-#  latitude        :float
-#  longitude       :float
 #  name            :string
 #  status          :integer          default("available")
 #  created_at      :datetime         not null


### PR DESCRIPTION
Removes coordinates from the Item model. You can `rails db:migrate` and check your schema to confirm.
![image](https://user-images.githubusercontent.com/85902450/172015407-a406e578-ada8-40c4-8f51-4b3fc3434522.png)
