### PR TITLE
prevent app from crashing on show page

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,7 @@
 class ItemsController < ApplicationController
   # a user doesn't have to log in to visit the index and show pages
-  skip_before_action :authenticate_user!, only: %i[index show]
+  skip_before_action :authenticate_user!, only: :index
   # a user has to log in to like an item
-  before_action :authenticate_user!, only: %i[toggle_favorite]
   before_action :find_item, only: %i[show toggle_favorite]
 
   def index

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: [:home]
 
-  def home
-  end
+  def home; end
 end


### PR DESCRIPTION
Because we look for the `current_user.id` on the show page, but also allow a user to not be signed in, it crashes on the show page. This prevents a user from viewing the show page before they sign in.