### PR TITLE
Fix filtering in index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,6 @@ class ItemsController < ApplicationController
       @users = User.near(params[:postal_code], 5)
       # Get all of these users items
       @items = @users.map {|u| u.items}.flatten
-      raise
     elsif params[:query].present?
       @items = Item.search_index(params[:query])
       @users = User.all

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,22 +5,22 @@ class ItemsController < ApplicationController
   before_action :find_item, only: %i[show toggle_favorite]
 
   def index
-    if params[:query].present?
-      @items = Item.search_index(params[:query])
-    else
-      @items = Item.all.order(id: :desc)
-    end
-
     # Filter by postal code
     if params[:postal_code].present?
       # Filter users if items are near (5km)
       @users = User.near(params[:postal_code], 5)
       # Get all of these users items
       @items = @users.map {|u| u.items}.flatten
+      raise
+    elsif params[:query].present?
+      @items = Item.search_index(params[:query])
+      @users = User.all
+    else
+      @items = Item.all.order(id: :desc)
+      @users = User.all
     end
 
     # Geocoder
-    @users = User.all
     @markers = @users.geocoded.map do |user|
       {
         lat: user.latitude,

--- a/app/javascript/controllers/postal_code_controller.js
+++ b/app/javascript/controllers/postal_code_controller.js
@@ -30,10 +30,11 @@ export default class extends Controller {
         const cardsItems = document.querySelector("#cards-items");
         cardsItems.innerHTML='';
 
+        // This needs to be updated
         items.forEach((item) => {
           console.log(item)
           const itemCard = `<div class="card-product" data-id="${item[0].id}">
-              <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/skateboard.jpg" />
+              <img src="https://images.unsplash.com/photo-1554136383-fa88b2d86aaf?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=928&q=80" />
               <div class="card-product-infos">
                 <h2>${item[0].name}</h2>
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  request_id :bigint
+#  request_id :bigint           not null
 #  user_id    :bigint           not null
 #
 class Message < ApplicationRecord

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2022_06_04_160852) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "request_id"
+    t.bigint "request_id", null: false
     t.index ["request_id"], name: "index_messages_on_request_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -6,7 +6,7 @@
 #  content    :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  request_id :bigint
+#  request_id :bigint           not null
 #  user_id    :bigint           not null
 #
 require "test_helper"


### PR DESCRIPTION
Fix issue where @users or @items was being reassigned accidentally in the items controller #index method.
This fix is hard to see at the moment, due to the DOM not accurately showing our code, but if you use a raise, then open the console and inspect the error, it will bring you to the raise page. From there, you can use `@users.size` or `@users.length `to see if it's really filtering the number of items being displayed, after entering a postal code.

Please take your time to review this, thank you.