### PR TITLE
changed object-fit from contain to cover

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -14,7 +14,8 @@
   // keep images fixed at width of 120px and remove height:100% so all images align
   width: 120px;
   // change to contain looks better than cover
-  object-fit: contain;
+  object-fit: cover;
+  // changed to cover to fill the height of the picture
 }
 
 .card-product h2 {


### PR DESCRIPTION
@MarlAndre @DenzelBraithwaite @stshayna 
Changed from object-fit contain to cover. It's true that the picture expands to cover the full width of the box, but using other values strech or shrink the pictures
<img width="588" alt="Screen Shot 2022-06-09 at 8 57 54 PM" src="https://user-images.githubusercontent.com/85533872/172969408-fc664bd7-8ded-4e59-9008-75d8cf867cd9.png">

