### PR TITLE
fixed toggle effect of fav icon

### DIFF
--- a/app/assets/stylesheets/components/_like_button.scss
+++ b/app/assets/stylesheets/components/_like_button.scss
@@ -1,3 +1,10 @@
-.red {
-  color: red;
+.social-media {
+  .like {
+    font-size: 2.5rem;
+    text-shadow: white 1px 0 8px;
+    margin-bottom: 5px;
+  }
+  .rose {
+    color: $rose;
+  }
 }

--- a/app/assets/stylesheets/components/_like_button.scss
+++ b/app/assets/stylesheets/components/_like_button.scss
@@ -5,6 +5,6 @@
     margin-bottom: 5px;
   }
   .rose {
-    color: $rose;
+    color: red;
   }
 }

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -14,4 +14,3 @@ $ivory: #FFFFF0;
 $light-green: #8BAD85;
 $rose: #814B67;
 $dark-green: #2B3D29;
-

--- a/app/javascript/controllers/toggle_favorite_controller.js
+++ b/app/javascript/controllers/toggle_favorite_controller.js
@@ -4,12 +4,8 @@ import ContextExclusionPlugin from "webpack/lib/ContextExclusionPlugin";
 export default class extends Controller {
   static targets = [ "icon" ]
 
-  connect() {
-    this.inputTarget.value = ''
-  }
-
-  red(event) {
-    this.iconTarget.querySelector('i').classList.toggle('red')
+  rose(event) {
+    this.iconTarget.querySelector('i').classList.toggle('rose')
   }
 
   //Like button effects

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,9 +42,9 @@
       <div class="social-media" data-controller="toggle-favorite">
         <p class="distance"># km away</p>
         <div class="d-flex">
-          <div data-action="click->toggle-favorite#red" data-toggle-favorite-target="icon">
+          <div data-action="click->toggle-favorite#rose" data-toggle-favorite-target="icon">
             <%= link_to toggle_favorite_item_path(@item), remote: true, method: :post do %>
-              <i class="fas fa-heart <%= 'red' if current_user.favorited?(@item) %>"favorite_border></i>
+              <i class="fas fa-heart like <%= 'rose' if current_user.favorited?(@item) %>"></i>
             <% end %>
           </div>
           <%# commented out 'share' button because we don't have the share function (yet) %>


### PR DESCRIPTION
![Screenshot 2022-06-11 at 4 28 52 PM](https://user-images.githubusercontent.com/75033073/173203886-d932eed4-2620-4c1b-9aad-cb92a8318d77.png)
![Screenshot 2022-06-11 at 4 29 04 PM](https://user-images.githubusercontent.com/75033073/173203889-fd1ef2fe-5a88-429f-be57-4eedcf9977af.png)

The error was probably caused by the class `favorite_border` added by another branch, the class is removed given the relevant js codes were commented out and not in use. 
Also changed the color of the favorite icon to our theme color as suggested in feedback session.
