### PR TITLE
add item_type into search filter

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -41,7 +41,7 @@ class Item < ApplicationRecord
   # added "pg_search" gem to filter the index by name/description
   include PgSearch::Model
   pg_search_scope :search_index,
-    against: %i[name description],
+    against: %i[name description item_type],
     associated_against: { user: :username },
     using: { tsearch: { prefix: true } }
 


### PR DESCRIPTION
added `:item_type` into pg_search filter so we can search "meal" / "ingredient".
