### PR TITLE
Card colors status

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -7,6 +7,9 @@
   align-items: center;
   gap: 16px;
   margin-bottom: 16px;
+  &.gray {
+    background: rgba(128, 128, 128, 0.4);
+  }
 }
 
 .card-product img {

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -90,7 +90,7 @@
           <div class="cards items" id="cards-items" data-postal-code-target="items">
             <% @items.each do |item| %>
               <%= link_to item_path(item), class: "text-decoration-none" do%>
-                <div class="card-product">
+                <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
                   <% if item.photos.attached? %>
                     <%= cl_image_tag item.photos.first.key, width: "100%", height: 400 %>
                   <% else %>
@@ -99,7 +99,13 @@
 
                   <div class="card-product-infos">
                     <h2><%= item.name.capitalize %></h2>
-                    <h3><%= truncate(item.description, :length => 93) %></h3>
+                    <% if item.donated? %>
+                      <h3>This item was donated.</h3>
+                    <% elsif item.reserved? %>
+                      <h3>This item is reserved by a receiver.</h3>
+                    <% else %>
+                      <h3><%= truncate(item.description, :length => 93) %></h3>
+                    <% end %>
                     <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
                     <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>
                   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -102,7 +102,7 @@
                     <% if item.donated? %>
                       <h3>This item was donated.</h3>
                     <% elsif item.reserved? %>
-                      <h3>This item is reserved by a receiver.</h3>
+                      <h3>This item is reserved.</h3>
                     <% else %>
                       <h3><%= truncate(item.description, :length => 93) %></h3>
                     <% end %>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -24,7 +24,7 @@
                 <% if item.donated? %>
                   <h3>This item was donated.</h3>
                 <% elsif item.reserved? %>
-                  <h3>This item is reserved by a receiver.</h3>
+                  <h3>This item is reserved.</h3>
                 <% else %>
                   <h3><%= truncate(item.description, :length => 93) %></h3>
                 <% end %>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -11,7 +11,7 @@
           <% item = Item.find(fav.favoritable_id) %>
           <%= link_to item_path(item), class: "text-decoration-none" do%>
 
-            <div class="card-product">
+            <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
                 <%# hardcoded image for item %>
                   <% if item.photos.attached? %>
                     <%= cl_image_tag item.photos.first.key, width: "100%", height: 400 %>
@@ -21,7 +21,13 @@
 
               <div class="card-product-infos">
                 <h2><%= item.name.capitalize %></h2>
-                <h3><%= truncate(item.description, :length => 93) %></h3>
+                <% if item.donated? %>
+                  <h3>This item was donated.</h3>
+                <% elsif item.reserved? %>
+                  <h3>This item is reserved by a receiver.</h3>
+                <% else %>
+                  <h3><%= truncate(item.description, :length => 93) %></h3>
+                <% end %>
                 <p><i class="fas fa-map-marker-alt"></i> <%= item.user.address %></p>
               </div>
             </div>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -27,7 +27,7 @@
                     <% if item.donated? %>
                       <h3>This item was donated.</h3>
                     <% elsif item.reserved? %>
-                      <h3>This item is reserved by a receiver.</h3>
+                      <h3>This item is reserved.</h3>
                     <% else %>
                       <h3><%= truncate(item.description, :length => 93) %></h3>
                     <% end %>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -14,7 +14,7 @@
           <div class="cards items my-4" id="cards-items">
             <% @items.each do |item| %>
               <%= link_to item_path(item), class: "text-decoration-none" do%>
-                <div class="card-product">
+                <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
                   <%# hardcoded image for item %>
                   <% if item.photos.attached? %>
                     <%= cl_image_tag item.photos.first.key, width: "100%", height: 400 %>
@@ -24,7 +24,13 @@
 
                   <div class="card-product-infos">
                     <h2><%= item.name.capitalize %></h2>
-                    <h3><%= truncate(item.description, :length => 93) %></h3>
+                    <% if item.donated? %>
+                      <h3>This item was donated.</h3>
+                    <% elsif item.reserved? %>
+                      <h3>This item is reserved by a receiver.</h3>
+                    <% else %>
+                      <h3><%= truncate(item.description, :length => 93) %></h3>
+                    <% end %>
                     <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
                     <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>
                   </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -11,7 +11,7 @@
         <% unless request.messages.last.nil? %>
           <%= link_to request_path(request) do %>
             <%# each request is a flex card %>
-            <div class="ripple shadow request-card <%= request.item.donated? ? 'donated' : '' %>">
+            <div class="ripple shadow request-card <%= (request.item.donated? || request.item.reserved?) ? 'donated' : '' %>">
               <%# image is the first div %>
               <%# To insert dynamic images for all items %>
               <%= image_tag "ingredients/cucumber_two.jpg", class: "img" %>
@@ -23,8 +23,10 @@
                   <span><%= request.receiver.username %></span>
                 <% end %>
                 <strong><%= request.item.name %></strong>
-                <% if request.item.status == 'donated' %>
-                  <em>This item was donated.</em>
+                <% if request.item.donated? %>
+                  <em>This item was donated to another receiver.</em>
+                <% elsif request.item.reserved? %>
+                  <em>This item was reserved by another receiver.</em>
                 <% else %>
                   <%# only part of the message is previewed if it's too long %>
                   <% if current_user == request.messages.last.user %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -26,7 +26,7 @@
                 <% if request.item.donated? %>
                   <em>This item was donated.</em>
                 <% elsif request.item.reserved? %>
-                  <em>This item is reserved by a receiver.</em>
+                  <em>This item is reserved.</em>
                 <% else %>
                   <%# only part of the message is previewed if it's too long %>
                   <% if current_user == request.messages.last.user %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -11,7 +11,7 @@
         <% unless request.messages.last.nil? %>
           <%= link_to request_path(request) do %>
             <%# each request is a flex card %>
-            <div class="ripple shadow request-card <%= (request.item.donated? || request.item.reserved?) ? 'donated' : '' %>">
+            <div class="ripple shadow request-card <%= 'donated' if (request.item.donated? || request.item.reserved?) %>">
               <%# image is the first div %>
               <%# To insert dynamic images for all items %>
               <%= image_tag "ingredients/cucumber_two.jpg", class: "img" %>
@@ -24,9 +24,9 @@
                 <% end %>
                 <strong><%= request.item.name %></strong>
                 <% if request.item.donated? %>
-                  <em>This item was donated to another receiver.</em>
+                  <em>This item was donated.</em>
                 <% elsif request.item.reserved? %>
-                  <em>This item was reserved by another receiver.</em>
+                  <em>This item is reserved by a receiver.</em>
                 <% else %>
                   <%# only part of the message is previewed if it's too long %>
                   <% if current_user == request.messages.last.user %>


### PR DESCRIPTION
![Screenshot 2022-06-11 at 11 22 06 PM](https://user-images.githubusercontent.com/75033073/173212951-fb804aec-21e9-4700-b05c-e2eaae7249a5.png)
![Screenshot 2022-06-11 at 11 54 39 PM](https://user-images.githubusercontent.com/75033073/173213672-933d2614-3bd3-4bcf-8310-3ec22072489e.png)


Changes in this PR:
when an item is `reserved` / `donated`, its index card and message cards will all change to gray color. `item.description` in those cards will be replaced by `This item was donated.` / `This item is reserved.`
Used one shade of gray color only, otherwise the page has too many colors i think.
