### PR TITLE
make item description shorter in cards

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -104,7 +104,7 @@
                     <% elsif item.reserved? %>
                       <h3>This item is reserved.</h3>
                     <% else %>
-                      <h3><%= truncate(item.description, :length => 85) %></h3>
+                      <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
                     <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
                     <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -28,7 +28,7 @@
                   <h3>This item is reserved.</h3>
                   <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% else %>
-                  <h3><%= truncate(item.description, :length => 93) %></h3>
+                  <h3><%= truncate(item.description, :length => 85) %></h3>
                   <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% end %>
                 <p><i class="fas fa-map-marker-alt"></i> <%= item.user.address %></p>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -28,7 +28,7 @@
                   <h3>This item is reserved.</h3>
                   <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% else %>
-                  <h3><%= truncate(item.description, :length => 85) %></h3>
+                  <h3><%= truncate(item.description, :length => 61) %></h3>
                   <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% end %>
                 <p><i class="fas fa-map-marker-alt"></i> <%= item.user.address %></p>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -29,7 +29,7 @@
                     <% elsif item.reserved? %>
                       <h3>This item is reserved.</h3>
                     <% else %>
-                      <h3><%= truncate(item.description, :length => 85) %></h3>
+                      <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
                     <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
                     <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -29,7 +29,7 @@
                     <% elsif item.reserved? %>
                       <h3>This item is reserved.</h3>
                     <% else %>
-                      <h3><%= truncate(item.description, :length => 93) %></h3>
+                      <h3><%= truncate(item.description, :length => 85) %></h3>
                     <% end %>
                     <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
                     <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>


### PR DESCRIPTION
There's a previous branch that shorten the item description in index cards, so making the same change for the item cards in other pages as well and the cards will have better padding.