### PR TITLE
udpated user images in cards

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -66,8 +66,10 @@
     <div class="card-user">
       <% if @item.user == User.first %>
         <%= image_tag "demo_user.png", class: "avatar" %>
+      <% elsif @item.user.username == 'Shayna' %>
+        <%= image_tag "giver_shayna.png", class: "avatar" %>
       <% else %>
-        <img class="avatar" alt="avatar" src="https://kitt.lewagon.com/placeholder/users/cveneziani" />
+        <%= image_tag "landingpage.png", class: "avatar" %>
       <% end %>
       <div class="card-description">
         <p class="username"><%= @item.user.username.capitalize %> is giving away</p>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -20,10 +20,12 @@
         </div>
       </div>
       <div class="image">
-        <% if @request.item.user.username == "Shayna" || "shayna" %>
+        <% if @request.item.user.username == "Shayna" %>
           <%= image_tag "giver_shayna.png", class: "avatar-bordered" %>
-        <% else %>
+        <% elsif @request.item.user == User.first %>
           <%= image_tag "demo_user.png", class: "avatar-bordered" %>
+        <% else %>
+          <%= image_tag "landingpage.png", class: "avatar-bordered" %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
Updated avatar images in item cards with three scenarios:
1. Demo user 'Justin' will use Denzel's img.
2. Giver 'Shayna' will use Shayna's img.
3. Everyone else will use the landing page img.
![Screenshot 2022-06-12 at 6 42 41 PM](https://user-images.githubusercontent.com/75033073/173256734-5a443153-9f03-4fa2-b9cd-5b609660012a.png)
![Screenshot 2022-06-12 at 6 42 02 PM](https://user-images.githubusercontent.com/75033073/173256735-9b103f39-1776-4d4b-b763-a10447417252.png)
![Screenshot 2022-06-12 at 6 41 19 PM](https://user-images.githubusercontent.com/75033073/173256736-052e04a0-50ad-4728-ac86-e2fc5eb92d3b.png)

