### PR TITLE
Card index

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -47,12 +47,16 @@
   color: black;
 }
 
+.card-location {
+  margin-top: 12px;
+}
+
 .text-decoration-none {
   text-decoration: none;
 }
 
 .card-product .card-product-infos {
-  padding: 16px;
+  margin-right: 8px;
 }
 
 // Smallest device

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -103,7 +103,7 @@
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
                       <div class="d-flex justify-content-between card-location">
-                        <p><%= "#{@distances_between_other_users[item.user.id]} km" %></p>
+                        <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
                         <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
                       </div>
                   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -102,8 +102,10 @@
                     <% else %>
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
-                    <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
-                    <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>
+                      <div class="d-flex justify-content-between card-location">
+                        <p><%= "#{@distances_between_other_users[item.user.id]} km" %></p>
+                        <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                      </div>
                   </div>
                 </div>
               <% end %>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -36,12 +36,13 @@
                   <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% else %>
                   <h3><%= truncate(item.description, :length => 61) %></h3>
-                  <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
+                  <div class="d-flex justify-content-between card-location">
+                      <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
+                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                    </div>
                 <% end %>
-                <p><i class="fas fa-map-marker-alt"></i> <%= item.user.address %></p>
               </div>
             </div>
-
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
I changed the styling of the cards in the index.
Address and distance are on the same line, and distance is bold to make it pop more.
I used truncate on the address otherwise it was displaying everything on a second line and was messing with the desired styling.

<img width="248" alt="index card" src="https://user-images.githubusercontent.com/15382972/173697225-81837061-7fda-43b2-9739-ce3c12320908.PNG">

