### PR TITLE
reserved and donate item cards have different colors

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -7,8 +7,11 @@
   align-items: center;
   gap: 16px;
   margin-bottom: 16px;
-  &.gray {
-    background: rgba(128, 128, 128, 0.4);
+  &.reserved {
+    background: rgba(128, 128, 128, 0.3);
+  }
+  &.donated {
+    background: rgba(128, 128, 128, 0.8);
   }
   .image {
     width: 120px;

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -88,7 +88,7 @@
           <div class="cards items" id="cards-items" data-postal-code-target="items">
             <% @items.each do |item| %>
               <%= link_to item_path(item), class: "text-decoration-none" do%>
-                <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
+                <div class="card-product <%= ('donated' if item.donated?) || ('reserved' if item.reserved?) %>">
                   <div class="image">
                     <%= cl_image_tag item.photos.first.key, class: "img" %>
                   </div>
@@ -102,10 +102,10 @@
                     <% else %>
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
-                      <div class="d-flex justify-content-between card-location">
-                        <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                        <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
-                      </div>
+                    <div class="d-flex justify-content-between card-location">
+                      <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
+                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                    </div>
                   </div>
                 </div>
               <% end %>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -9,7 +9,7 @@
 
 <div class="my-favorites">
   <div class="heading">
-    <h5>My Favorites</h5>
+    <h5>My favorites</h5>
   </div>
   <div class="container my-4">
     <div class="cards items" id="cards-items">
@@ -20,8 +20,7 @@
           <% item = Item.find(fav.favoritable_id) %>
           <%= link_to item_path(item), class: "text-decoration-none" do%>
 
-            <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
-                <%# hardcoded image for item %>
+            <div class="card-product <%= ('donated' if item.donated?) || ('reserved' if item.reserved?) %>">
                 <div class="image">
                   <%= cl_image_tag item.photos.first.key, class: "img" %>
                 </div>
@@ -30,17 +29,15 @@
                 <h2><%= item.name.capitalize %></h2>
                 <% if item.donated? %>
                   <h3>This item was donated.</h3>
-                  <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% elsif item.reserved? %>
                   <h3>This item is reserved.</h3>
-                  <h3><%= @distances_between_other_users[item.user.id] %> km</h3>
                 <% else %>
                   <h3><%= truncate(item.description, :length => 61) %></h3>
-                  <div class="d-flex justify-content-between card-location">
-                      <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
-                    </div>
                 <% end %>
+                <div class="d-flex justify-content-between card-location">
+                  <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
+                  <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                </div>
               </div>
             </div>
           <% end %>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -14,7 +14,7 @@
           <div class="cards items my-4" id="cards-items">
             <% @items.each do |item| %>
               <%= link_to item_path(item), class: "text-decoration-none" do%>
-                <div class="card-product <%= 'gray' if (item.donated? || item.reserved?) %>">
+                <div class="card-product <%= ('donated' if item.donated?) || ('reserved' if item.reserved?) %>">
                   <div class="image">
                     <%= cl_image_tag item.photos.first.key, class: "img" %>
                   </div>
@@ -28,8 +28,10 @@
                     <% else %>
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
-                    <h3><%= "#{@distances_between_other_users[item.user.id]} km" %></h3>
-                    <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= item.user.address %></p>
+                    <div class="d-flex justify-content-between card-location">
+                      <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
+                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                    </div>
                   </div>
                 </div>
               <% end %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -20,7 +20,7 @@
         <% unless request.messages.last.nil? %>
           <%= link_to request_path(request) do %>
             <%# each request is a flex card %>
-            <div class="ripple shadow request-card <%= 'donated' if (request.item.donated? || request.item.reserved?) %>">
+            <div class="ripple shadow request-card <%= ('donated' if item.donated?) || ('reserved' if item.reserved?) %>">
               <%# image is the first div %>
               <div class="image">
                 <%= cl_image_tag request.item.photos.first.key, class: "img" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -181,8 +181,6 @@ add_allergens_and_diets(shaynas_meal)
   address: '5305 drolet st, montreal'
 )
 puts " Demo persona: #{@williams.username.light_cyan} has been created to rent #{@shayna.username.light_cyan}'s #{shaynas_meal.name.cyan} meal"
-puts "#{'✓ Personas '.light_green}created"
-puts ''
 
 # Demo user JF will be the GIVER whose item is favorited by Justin.
 @jf = User.create!(
@@ -202,8 +200,12 @@ jfs_ingredient = Item.new(
 jfs_ingredient.photos.attach(io: File.open("app/assets/images/ingredients/#{@ingredients.last["photo"]}"), filename: @ingredients.last["photo"])
 jfs_ingredient.save!
 
-puts " Demo persona: #{@jf.username.light_cyan} has been created with a #{jfs_ingredient.name.cyan} ingredient"
+# Add J-F's ingredient to Justin's list of favorites.
+@justin.favorite(jfs_ingredient)
 
+puts " Demo persona: #{@jf.username.light_cyan} has been created with a #{jfs_ingredient.name.cyan} ingredient"
+puts "#{'✓ Personas '.light_green}created"
+puts ''
 #############################################################################
 #----------------------------SEED DB WITH USERS-----------------------------#
 #############################################################################


### PR DESCRIPTION
Few changes here:
1. For items that are reserved or donated, their cards will be in different colors, i.e. gray and dark-gray.
2. Fixed to have the same styling for distance and address on the same line in the item cards for all pages.
3. In seeds, Justin the demo user has favorited the 'sugar' ingredient.