### PR TITLE
remove blue hover color

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -25,6 +25,9 @@
       line-height: 40px;
     }
   }
+  a:active {
+    color: white;
+  }
 }
 
 // Styling tabs


### PR DESCRIPTION
![Screenshot 2022-06-14 at 10 22 38 PM](https://user-images.githubusercontent.com/75033073/173723039-46409e0d-9098-4f6f-96cc-d355af526008.png)

Added an active class to the link in the button so it doesn't appear blue when clicked.