### PR TITLE
Fix logo container

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -45,11 +45,11 @@
 
 .back-btn-container {
   display: flex;
-  margin-bottom: 36px;
+  margin-bottom: 16px;
   margin-top: 36px;
   &.show {
     margin-top: 0;
-    margin-bottom: 16px;
+    margin-bottom: 8px;
   }
   p {
     color: $dark-green;

--- a/app/assets/stylesheets/components/_container.scss
+++ b/app/assets/stylesheets/components/_container.scss
@@ -6,19 +6,16 @@ body {
   display: flex;
   color: $ivory;
   background-color: $rose;
-  padding-left: 12px;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  padding: 1px;
-  padding-left: 12px;
   z-index: 1030;
+  height: 48px;
   p {
     font-size: 24px;
     font-weight: 600;
-    margin-left: 8px;
-    line-height: 1.3;
+    margin: auto 8px;
   }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,14 +18,12 @@
 
   <body>
 <br>
-  <div class="logo-container">
-    <%= image_tag "map_icon.png", width: "30", height: "30"%>
-    <p>Food4All</p>
+  <div class="logo-container d-flex justify-content-center align-items-center">
+    <%= image_tag "map_icon.png", width: "30", height: "30"%><p>Food4All</p>
   </div>
 
     <% unless current_page?(root_path) %>
-    <%# app-container just for Requests#index page %>
-    <%# Page heading needs 100% width %>
+      <%# Page heading needs 100% width %>
       <% if params[:controller] == "requests" && params[:action] == "index" ||
       params[:controller] == "pages" && params[:action] == "my_favorites" ||
       params[:controller] == "items" && params[:action] == "my_items" ||
@@ -60,7 +58,6 @@
         <div class="page-content">
           <p class="notice"><%= notice %></p>
           <p class="alert"><%= alert %></p>
-
           <%= yield %>
         </div>
       </div>


### PR DESCRIPTION
![Screenshot 2022-06-14 at 11 51 42 PM](https://user-images.githubusercontent.com/75033073/173733355-baa59fdf-abdf-432f-a703-da9455701e0c.png)

Fixed logo container - the logo is now centered.
Also reduced margin around `back` button in all the pages.