### PR TITLE
Index no donated

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,7 @@ class ItemsController < ApplicationController
     @users = User.where(id: users_with_items.map(&:id)).near(@postal_code, 50)
 
     # Get the list of all available/reserved items of these users
-    @items = @users.map(&:items).flatten
+    @items = @users.map(&:items).flatten.select { |item| item.available? || item.reserved? }
 
     # Filter items if there is a search query
     if params[:query].present?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,7 @@ class ItemsController < ApplicationController
     @users = User.where(id: users_with_items.map(&:id)).near(@postal_code, 50)
 
     # Get the list of all available/reserved items of these users
-    @items = @users.map(&:items).flatten.select { |item| item.available? || item.reserved? }
+    @items = @users.map(&:items).flatten
 
     # Filter items if there is a search query
     if params[:query].present?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,12 +15,12 @@ class ItemsController < ApplicationController
     # Get all users near the postal_code
     @users = User.where(id: users_with_items.map(&:id)).near(@postal_code, 50)
 
-    # Get the list of all items of these users
-    @items = @users.map {|u| u.items}.flatten
+    # Get the list of all available/reserved items of these users
+    @items = @users.map(&:items).flatten.select { |item| item.available? || item.reserved? }
 
     # Filter items if there is a search query
     if params[:query].present?
-      @items = Item.where(id: @items.map(&:id)).search_index(params[:query])
+      @items = Item.where(id: @items.map(&:id)).search_index(params[:query]).select { |item| item.available? || item.reserved? }
     end
 
     # Geocoder

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -102,9 +102,9 @@
                     <% else %>
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
-                    <div class="d-flex justify-content-between card-location">
+                    <div class="d-flex card-location">
                       <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                      <p><i class="fas fa-map-marker-alt ms-3"></i>&nbsp<%= truncate(item.user.address, :length => 28) %></p>
                     </div>
                   </div>
                 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -11,16 +11,16 @@
     <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
       <div class="carousel-inner">
         <% @item.photos.each_with_index do |photo, index| %>
-        <% if index == 0 %>
-        <div class="carousel-item active">
-            <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%" %>
-        </div>
-        <% else %>
-        <div class="carousel-item">
-            <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%"  %>
-        </div>
-          <% end  %>
-        <% end  %>
+          <% if index == 0 %>
+            <div class="carousel-item active">
+              <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%" %>
+            </div>
+          <% else %>
+            <div class="carousel-item">
+              <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%" %>
+            </div>
+          <% end %>
+        <% end %>
       </div>
 
       <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleControls" data-bs-slide="prev">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -41,13 +41,11 @@
       </div>
       <div class="social-media" data-controller="toggle-favorite">
         <p class="distance"># km away</p>
-          <div data-action="click->toggle-favorite#rose" data-toggle-favorite-target="icon">
-            <%= link_to toggle_favorite_item_path(@item), remote: true, method: :post do %>
-              <i class="fas fa-heart like <%= 'rose' if current_user.favorited?(@item) %>"></i>
-            <% end %>
-          </div>
-          <%# commented out 'share' button because we don't have the share function (yet) %>
-          <%# <a href="#"><i class="fas fa-share-alt"></i></a> %>
+        <div data-action="click->toggle-favorite#rose" data-toggle-favorite-target="icon">
+          <%= link_to toggle_favorite_item_path(@item), remote: true, method: :post do %>
+            <i class="fas fa-heart like <%= 'rose' if current_user.favorited?(@item) %>"></i>
+          <% end %>
+        </div>
       </div>
     </div>
 
@@ -74,35 +72,31 @@
     </div>
 
     <div class="details">
-        <h6><strong>Description</strong></h6>
-        <%= @item.description.capitalize %>
-
-      <% unless @diets.nil? %>
-        <% @allergens.each do |allergen| %>
-          <p><i class="fas fa-exclamation-triangle"></i></i>&nbsp<%= allergen.name.capitalize %></li></p>
-        <% end %>
+      <h6><strong>Description</strong></h6>
+      <%= @item.description.capitalize %>
+      <p></p>
+      <% unless @diets.empty? %>
+        <i class="fas fa-exclamation-triangle"></i>
+        <%= @allergens.map { |allergen| allergen.name.capitalize }.join(", ") %>
       <% end %>
-      <% unless @diets.nil? %>
-        <% @diets.each do |diet| %>
-         <p><i class="fab fa-envira"></i>&nbsp<%= diet.name.capitalize %></li></p>
-        <% end %>
+      <p></p>
+      <% unless @diets.empty? %>
+        <i class="fab fa-envira"></i>
+        <%= @diets.map { |diet| diet.name.capitalize }.join(", ") %>
       <% end %>
-
-    </ul>
+    </div>
   </div>
 
-    <div class="card-category"
-        id="map"
-        style="width: 100%;
-        height: 400px;"
-        data-controller="mapbox"
-        data-mapbox-markers-value="<%= @markers.to_json %>"
-        data-mapbox-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"
-        >
-    </div>
-
+  <div class="card-category"
+    id="map"
+    style="width: 100%;
+    height: 400px;"
+    data-controller="mapbox"
+    data-mapbox-markers-value="<%= @markers.to_json %>"
+    data-mapbox-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"
+    >
+  </div>
 </div>
-
 
 <div class="my-5">
   <%# owner cannot request for his/her own items. %>

--- a/app/views/pages/my_favorites.html.erb
+++ b/app/views/pages/my_favorites.html.erb
@@ -34,9 +34,9 @@
                 <% else %>
                   <h3><%= truncate(item.description, :length => 61) %></h3>
                 <% end %>
-                <div class="d-flex justify-content-between card-location">
+                <div class="d-flex card-location">
                   <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                  <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                  <p><i class="fas fa-map-marker-alt ms-3"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
                 </div>
               </div>
             </div>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -28,9 +28,9 @@
                     <% else %>
                       <h3><%= truncate(item.description, :length => 61) %></h3>
                     <% end %>
-                    <div class="d-flex justify-content-between card-location">
+                    <div class="d-flex card-location">
                       <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                      <p><i class="fas fa-map-marker-alt ms-2"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                      <p><i class="fas fa-map-marker-alt ms-3"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
                     </div>
                   </div>
                 </div>

--- a/app/views/profiles/my_profile.html.erb
+++ b/app/views/profiles/my_profile.html.erb
@@ -30,7 +30,7 @@
                     <% end %>
                     <div class="d-flex justify-content-between card-location">
                       <strong><p><%= "#{@distances_between_other_users[item.user.id]} km" %></p></strong>
-                      <p><i class="fas fa-map-marker-alt"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
+                      <p><i class="fas fa-map-marker-alt ms-2"></i>&nbsp<%= truncate(item.user.address, :length => 30) %></p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Please review some changes here:
1. Index page
- filter the `@items` in `items` controller so only available/reserved items will appear
- shorten address by 2 chars so it can be shown in one line
- add the same space between distance and address (did the same for item cards in my favs and my profile pages too)

Result (donated items not shown):
![Screenshot 2022-06-16 at 1 37 43 PM](https://user-images.githubusercontent.com/75033073/174132757-2881bd8f-aed3-4aca-9d33-6f3b245c8a5a.png)

2. Show page
- tidy up the div indentations
- group allergens/diets in one line
![Screenshot 2022-06-16 at 12 43 06 PM](https://user-images.githubusercontent.com/75033073/174132954-dc59a240-05f3-47a6-acfe-d7f8addcf276.png)