### PR TITLE
last item added to favorite or messages sent will be on top

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,7 @@ class PagesController < ApplicationController
     # Currently calculating the distance for ALL users each time, would like to reduce this in the future for performance.
     get_distance
 
-    @my_favorites = current_user.all_favorites
+    @my_favorites = current_user.all_favorites.order(id: :desc)
 
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,7 +3,7 @@ class RequestsController < ApplicationController
 
   def index
     # current user can only view the chats where s/he is a receiver/giver.
-    @requests = Request.where(receiver: current_user).or(Request.where(giver: current_user))
+    @requests = Request.where(receiver: current_user).or(Request.where(giver: current_user)).order(id: :desc)
   end
 
   # make sure only the current users can access the page, otherwise redirect to Requests#index page.


### PR DESCRIPTION
When we add something to favorite or we send a messages to request an item, it goes on top.
Here's a visual with favorites page :
![favorite](https://user-images.githubusercontent.com/15382972/174162417-6cbfc872-b1a1-4adc-a58d-2d681791a668.PNG)
![my favorites card](https://user-images.githubusercontent.com/15382972/174162423-f3397715-1ec2-428e-9569-bfcf7a776324.PNG)

