### PR TITLE
re-order the item.status

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
     @profile = User.find(current_user.id)
 
     # Items that the current user has requested.
-    @items = Item.joins(:requests).where(requests: {receiver_id: current_user.id }).order(id: :desc)
+    @items = Item.joins(:requests).where(requests: {receiver_id: current_user.id }).order(:status)
 
     # All users where the request receiver is the current user
     @users = User.joins(:requests_as_giver).where(requests_as_giver: { receiver_id: current_user.id })


### PR DESCRIPTION
requested items are now ordered by item.status.
![Screenshot 2022-06-16 at 8 13 58 PM](https://user-images.githubusercontent.com/75033073/174198141-b96ca58f-5877-4f6a-af5a-07b81ec77749.png)

