### PR TITLE
shorter item img in show page

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -145,6 +145,7 @@
 
 .carousel-item > img {
   object-fit: cover;
+  object-position: center;
 }
 
 .my-items {

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -13,11 +13,11 @@
         <% @item.photos.each_with_index do |photo, index| %>
           <% if index == 0 %>
             <div class="carousel-item active">
-              <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%" %>
+              <%= cl_image_tag photo.key, class:"expand", height: 312, width: "100%" %>
             </div>
           <% else %>
             <div class="carousel-item">
-              <%= cl_image_tag photo.key, class:"expand", height: 400, width: "100%" %>
+              <%= cl_image_tag photo.key, class:"expand", height: 312, width: "100%" %>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
Changed the height of the img in the show page so user can see `Description` once clicked it.
![Screenshot 2022-06-16 at 8 53 36 PM](https://user-images.githubusercontent.com/75033073/174201225-76baa5b6-8b61-4d79-bd21-ae29114d2fd6.png)

